### PR TITLE
Formalize contingency and summary of the organization itself.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,56 @@
 # dictation-toolbox
-Meta-repository for tracking and providing information about the organization itself.
+Meta-repository for tracking and providing information about the organization
+itself.
+
+## Summary
+
+dictation-toolbox is a loose organization intended to organize projects for
+users of voice recognition software, with a focus on customizability,
+flexibility, and programming/system administration/etc. We hope to help fill in
+the gap between commercially available solutions for common workflows and other
+workflows which require customization.
+
+We also intend to provide a contingency plan for projects to be "adopted" by
+new maintainers if their current maintainers leave without transferring control
+of the project. Each repository in dictation-toolbox has one or more owners
+responsible for it, and admins of dictation-toolbox agree not to use their
+admin privileges on repositories where they are not an owner, except in the
+case of all owners dropping out of all contact for four months.
+
+We are open to including other projects under these terms to better serve the
+needs of the dictation community. Please open an issue in this repository if
+you are interested. Historically, we have made all owners of all repositories
+in dictation-toolbox admins of the organization.
+
+## Projects
+
+The listed owners of each project, rather than the admins of dictation-toolbox,
+retain full control and responsibility for all aspects of their project.
+
+### aenea
+
+Owners: @calmofthestorm
+
+Client-server library for using voice macros from Dragon NaturallySpeaking and
+Dragonfly on remote/non-windows hosts using NatLink and Dragonfly.
+
+### aenea-grammars
+
+Owners: @calmofthestorm
+
+A collection of grammars written for use with Aenea, with an eye toward
+programming and use on Linux.
+
+### dragonfly-scripts
+
+Owners: @nirvdrum
+
+This repository contains a collection of Dragonfly Python-scripts, that can be
+used with Dragon NaturallySpeaking Professional.
+
+### aenea-resources
+
+Owners: @calmofthestorm
+
+Miscellaneous resources (cheatsheets, etc) for working with aenea and
+aenea-grammars.


### PR DESCRIPTION
With discussion of Caster joining dictation-toolbox, it's probably a good idea for us to formalize our agreement on exactly what dictation-toolbox is for. I've written this up as my best recollection of what we agreed to over email forever ago, but obviously I think the current admins should reach a consensus on this before we consider it binding.

I'm pretty flexible on the four months (I'd probably be fine with anything >=2 and <=12.)

I considered adding language about making changes to this document, and maybe we should, but my main concern is to formalize our ownership of the projects and all aspects of community maintenance belonging to the owners, rather than to the admins of dictation-toolbox, and I really want to keep the bureaucracy and process light weight.

I care a great deal about maintaining my control over my projects but not much about my control in the organization itself (if there were ever to be an unresolvable disagreement, for example, I'd likely be content to move my projects out of the org, and just leave a link in place and an agreement not to fork into where the repo used to be to avoid confusion).

But honestly if voice coding ever gets popular to the point where we reach disagreements that would be an awesome problem to have in a sense, since I feel like the much bigger threat is the transient nature and generally small size of the community.

So basically I'm not convinced we need to address this now, provided we're clear about repository ownership and "loose association", and set out clear terms for the contingency option.

nirvdrum@ I'll treat your approval as required on this, and will also reach out to the two private-membership admins, though I'm not anticipating any objections.